### PR TITLE
Included default conf.js file

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -1,0 +1,45 @@
+/**
+ * Default PM2 configuration.
+ * Default configuration is loaded from ~/.pm2/conf.js
+ * This file is used as a callback in case the above file doesn't exist or is empty.
+ */
+
+var p    = require('path');
+
+module.exports = function(DEFAULT_HOME) {
+
+  if (!DEFAULT_HOME)
+    return false;
+
+  var PM2_HOME = DEFAULT_HOME;
+
+  var pm2_conf = {
+    PM2_HOME                 : PM2_HOME,
+
+    PM2_LOG_FILE_PATH        : p.join(PM2_HOME, 'pm2.log'),
+    PM2_PID_FILE_PATH        : p.join(PM2_HOME, 'pm2.pid'),
+
+    DEFAULT_PID_PATH         : p.join(PM2_HOME, 'pids'),
+    DEFAULT_LOG_PATH         : p.join(PM2_HOME, 'logs'),
+    DUMP_FILE_PATH           : p.join(PM2_HOME, 'dump.pm2'),
+
+    DAEMON_RPC_PORT          : p.join(PM2_HOME, 'rpc.sock'),
+    DAEMON_PUB_PORT          : p.join(PM2_HOME, 'pub.sock'),
+    INTERACTOR_RPC_PORT      : p.join(PM2_HOME, 'interactor.sock'),
+
+    GRACEFUL_TIMEOUT         : parseInt(process.env.PM2_GRACEFUL_TIMEOUT) || 8000,
+    GRACEFUL_LISTEN_TIMEOUT  : parseInt(process.env.PM2_GRACEFUL_LISTEN_TIMEOUT) || 4000,
+
+    DEBUG                    : process.env.PM2_DEBUG || false,
+    WEB_INTERFACE            : parseInt(process.env.PM2_API_PORT)  || 9615,
+    MODIFY_REQUIRE           : process.env.PM2_MODIFY_REQUIRE || false,
+
+    PM2_LOG_DATE_FORMAT      : process.env.PM2_LOG_DATE_FORMAT !== undefined ? process.env.PM2_LOG_DATE_FORMAT : 'YYYY-MM-DD HH:mm:ss',
+
+    INTERACTOR_LOG_FILE_PATH : p.join(PM2_HOME, 'agent.log'),
+    INTERACTOR_PID_PATH      : p.join(PM2_HOME, 'agent.pid'),
+    INTERACTION_CONF         : p.join(PM2_HOME, 'agent.json5')
+  };
+
+  return pm2_conf || null;
+};

--- a/lib/mon.js
+++ b/lib/mon.js
@@ -67,7 +67,15 @@ Monitor.prototype._init = function(options){
   // Load PM2 config.
   var pm2ConfPath = path.join(options.pm2, 'conf.js');
   try {
-    options.pm2Conf = require(pm2ConfPath)(options.pm2);
+    // Try loading user-specific configuration
+    var pm2ConfFunction = require(pm2ConfPath);
+    if ('function' !== typeof pm2ConfFunction) {
+      // Not found or
+      // Does not export function (the file is empty by default)
+      // = Load default configuration file
+      pm2ConfFunction = require('./conf')
+    }
+    options.pm2Conf = pm2ConfFunction(options.pm2);
     if (!options.pm2Conf) {
       throw new Error(404);
     }


### PR DESCRIPTION
A default conf.js is bundled and loaded in case the user configured one is not found.
This fixes Tjatse/pm2-gui#10

I'm not sure if this is the best approach, but it works. Seeing a weird issue out of the box sucks.