### PR TITLE
Changes processDirname to be process directory

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -8,7 +8,7 @@ var spawn = cp.spawn
 var Monitor = require('./monitor')
 var Log = require('./util/log')
 
-var processDirname = path.resolve(__dirname, '../')
+var processDirname = path.resolve(process.cwd())
 var confFile = './pm2-gui.ini'
 var cmd = 'start'
 


### PR DESCRIPTION
Uses the process directory as the base for resolving all relative paths. Avoids using the installation directory.
